### PR TITLE
Add error handling for 401 status in auth interceptor

### DIFF
--- a/CookBook/src/app/Core/auth.interceptor.ts
+++ b/CookBook/src/app/Core/auth.interceptor.ts
@@ -7,12 +7,20 @@ export const authInterceptor: HttpInterceptorFn = (req, next) => {
   const token = authService.getToken();
 
   if (token) {
-    const cloned = req.clone({
+     req = req.clone({
       setHeaders: {
         Authorization: `Bearer ${token}`
       }
     });
-    return next(cloned);
   }
-  return next(req);
+  return next(req).pipe(
+  catchError((error: HttpErrorResponse) => {
+   if (error.status === 401) 
+   { 
+authService.logout();
+}
+return throwError(() => error);
+})
+    );
 };
+


### PR DESCRIPTION
Handle 401 errors by logging out the user.